### PR TITLE
Ensure that only one instance of each crafting feat is chosen

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -3155,11 +3155,12 @@ class SimplifiedCraftingModule {
     if (craftTab.length > 0) {
       try {
         const allActorFeats = actor.itemTypes.feat;
-
-        const relevantFeats = allActorFeats.filter((feat) =>
-          this.CRAFTING_FEAT_SLUGS.has(feat.slug)
+        
+        const relevantFeats = allActorFeats.filter((feat, index) =>
+          // only take the _first_ matching feat to ensure uniqueness
+          this.CRAFTING_FEAT_SLUGS.has(feat.slug) && allActorFeats.indexOf(feat) === index
         );
-
+          
         relevantFeats.sort((a, b) => a.name.localeCompare(b.name));
 
         let featListHtml = "";


### PR DESCRIPTION
Fixes #4 by ensuring that only one instance of a feat is selected per feat name.